### PR TITLE
Allow set custom URL of Riot instance host

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "config": {
     "serviceURL": "https://riot.im/app",
     "hasTeamID": false,
+    "hasCustomUrl": true,
     "urlInputSuffix": false,
     "hasNotificationSound": true,
     "hasIndirectMessages": true


### PR DESCRIPTION
Riot.im is opensource and very often used as self-hosted service on user domains.

So client urls may be different.
Also official Riot instance have three versions:
http://riot.im/app/
http://riot.im/staging/
http://riot.im/develop/

And Riot cloud based service suggests to use own hosts with Riot, instead of using it at riot.im website. So most of Matrix.org users use Riot on own domains, not the default one.